### PR TITLE
March 5 standard call

### DIFF
--- a/_posts/2020-03-20-notes-from-community-call-5-march-2020.md
+++ b/_posts/2020-03-20-notes-from-community-call-5-march-2020.md
@@ -20,8 +20,8 @@ categories:
 
 We discussed whether we needed to separate requirements related to governance into their own criteria in the Standard. Right now it's mostly baked into the criteria [Welcome contributions](https://standard.publiccode.net/criteria/open-to-contributions.html). We [have previously discussed](https://github.com/publiccodenet/standard/issues/282) how governance is handled in the Standard. We agreed to look into this more, especially now when some of the codebases we are working with are in the phase of developing their governance structures.
 
-We also discussed whether the Standard just accumulated more text during the last releases, and if there was a need to review possible  redundancies or obsolete parts. We had no clear answer but made a note to do a review before the next release.
+We also discussed whether the Standard just accumulated more text during the last releases, and if there was a need to review possible redundancies or obsolete parts. We had no clear answer but made a note to do a review before the next release.
 
-Lastly, we discussed how we could highlight vendors with experience of developing Standard compliant code. Perhaps we could publish a list of vendors that support the Standard on our website; "These are vendors you could call". To get on the list, a vendor could do a pull request and ask the public organization they worked with to review it.
+Lastly, we discussed how we could highlight vendors with experience of developing Standard-compliant code. Perhaps we could publish a list of vendors that support the Standard on our website: "These are vendors you could call". To get on the list, a vendor could do a pull request and ask the public organization they worked with to review it.
 
 Since we also have had some trouble with the stability of Jitsi as video call platform for the community calls, we decided to move back to Hangout meets.

--- a/_posts/2020-03-20-notes-from-community-call-5-march-2020.md
+++ b/_posts/2020-03-20-notes-from-community-call-5-march-2020.md
@@ -16,13 +16,6 @@ categories:
 * We published a guest blog post on the [Open Belgium website](https://2020.openbelgium.be/blogpost/collaborative-code-future-governance). Jan will be giving [a talk](https://2020.openbelgium.be/session/collaborative-code-future-governance) there tomorrow.
 * We are preparing to go to the [SCORE Developer Sprint Week](https://score.community/t/score-developer-sprint-week-in-ghent-2020/806) in Ghent 16-20 April.
 
-## Atendees
-
-On the call:
-- Jan (chair)
-- Alba (notes)
-- Boris
-
 ## Call notes
 
 We discussed whether we needed to separate requirements related to governance into their own criteria in the Standard. Right now it's mostly baked into the criteria [Welcome contributions](https://standard.publiccode.net/criteria/open-to-contributions.html). We [have previously discussed](https://github.com/publiccodenet/standard/issues/282) how governance is handled in the Standard. We agreed to look into this more, especially now when some of the codebases we are working with are in the phase of developing their governance structures.

--- a/_posts/2020-03-20-notes-from-community-call-5-march-2020.md
+++ b/_posts/2020-03-20-notes-from-community-call-5-march-2020.md
@@ -1,0 +1,34 @@
+---
+title: "Notes from community call - 5 March 2020"
+date: 2020-03-20
+author: Jan Ainali
+type: blogpost
+excerpt: Adding governance, fighting bloat and highlighting excellent vendors.
+categories:
+  - Community call
+---
+
+# Notes from the 5 March 2020 community call
+
+## Update from the Foundation for Public Code
+
+* We published our first [standard gap analysis of a codebase](https://github.com/Amsterdam/signals/blob/master/docs/topics/signalen-and-standard-for-public-code.md) in its repository.
+* We published a guest blog post on the [Open Belgium website](https://2020.openbelgium.be/blogpost/collaborative-code-future-governance). Jan will be giving [a talk](https://2020.openbelgium.be/session/collaborative-code-future-governance) there tomorrow.
+* We are preparing to go to the [SCORE Developer Sprint Week](https://score.community/t/score-developer-sprint-week-in-ghent-2020/806) in Ghent 16-20 April.
+
+## Atendees
+
+On the call:
+- Jan (chair)
+- Alba (notes)
+- Boris
+
+## Call notes
+
+We discussed whether we needed to separate requirements related to governance into their own criteria in the Standard. Right now it's mostly baked into the criteria [Welcome contributions](https://standard.publiccode.net/criteria/open-to-contributions.html). We [have previously discussed](https://github.com/publiccodenet/standard/issues/282) how governance is handled in the Standard. We agreed to look into this more, especially now when some of the codebases we are working with are in the phase of developing their governance structures.
+
+We also discussed whether the Standard just accumulated more text during the last releases, and if there was a need to review possible  redundancies or obsolete parts. We had no clear answer but made a note to do a review before the next release.
+
+Lastly, we discussed how we could highlight vendors with experience of developing Standard compliant code. Perhaps we could publish a list of vendors that support the Standard on our website; "These are vendors you could call". To get on the list, a vendor could do a pull request and ask the public organization they worked with to review it.
+
+Since we also have had some trouble with the stability of Jitsi as video call platform for the community calls, we decided to move back to Hangout meets.


### PR DESCRIPTION
Scheduled to be published tomorrow.

-----
[View rendered _posts/2020-03-20-notes-from-community-call-5-march-2020.md](https://github.com/publiccodenet/blog/blob/march5-standard-call/_posts/2020-03-20-notes-from-community-call-5-march-2020.md)