### PR TITLE
Add blogpost for 16 July call

### DIFF
--- a/_posts/2020-07-29-notes-from-community-call-16-july-2020.md
+++ b/_posts/2020-07-29-notes-from-community-call-16-july-2020.md
@@ -1,0 +1,46 @@
+---
+title: "Notes from community call - 16 July 2020"
+date: 2020-07-29
+author: Jan Ainali
+type: blogpost
+excerpt: Questions and answers from the community call
+categories:
+  - Community call
+---
+
+# 16 July 2020 Foundation for Public Code community call
+
+## Participants
+
+- [Elena Findley-de Regt](https://publiccode.net/team/elena-findley-de-regt.html) (chair)
+- [Joeri Bekker](https://github.com/joeribekker)
+- [Alba Roza](https://publiccode.net/team/alba-roza.html)
+- [Boris van Hoytema](https://publiccode.net/team/boris-van-hoytema.html)
+- [Eric Herman](https://publiccode.net/team/eric-herman.html)
+- [Jan Ainali](https://publiccode.net/team/jan-ainali.html)
+- [Laura Scheske](https://publiccode.net/team/laura-Scheske.html)
+
+## Update from the Foundation for Public Code
+
+- The Internet Society Netherlands gave us an encouragment award, as part of their [2020 innovation award](https://blog.publiccode.net/news/2020/06/17/isoc-encouragement-award-consider-us-encouraged.html)
+- We are currently following up after the OpenZaak market consultation
+
+## Notes
+
+After a round of introductions and a brief overview of the Foundation for Public Code, a wider unstructured discussion started that centered around the questions below.
+
+### I cannot find your blog from your website, where is it?
+
+We haven't put a link there yet because the blog is new and does not have much content (yet).
+But perhaps it's time to change that: we already have [an issue for it](https://github.com/publiccodenet/publiccode.net/issues/26).
+The blog is available at [blog.publiccode.net](https://blog.publiccode.net).
+
+### Am I meant to join this call? I feel like an outsider when most of the participants are from the Foundation for Public Code.
+
+Yes! If you want to be a part of the community, you are welcome.
+We find it important to have as many discussions in the open as possible and since our staff are also part of the community, most of them join these calls.
+Usually we like to use these calls to discuss topics that affect the ecosystem we are in and where wider input is useful rather than promoting our work.
+
+### Is there a list of codebases you work on? As a vendor I want to know codebases that I can offer help around, so this would be helpful from a commercial perspective.
+
+[We are working on that!](https://github.com/publiccodenet/publiccode.net/pull/57)

--- a/_posts/2020-07-29-notes-from-community-call-16-july-2020.md
+++ b/_posts/2020-07-29-notes-from-community-call-16-july-2020.md
@@ -18,7 +18,7 @@ categories:
 - [Boris van Hoytema](https://publiccode.net/team/boris-van-hoytema.html)
 - [Eric Herman](https://publiccode.net/team/eric-herman.html)
 - [Jan Ainali](https://publiccode.net/team/jan-ainali.html)
-- [Laura Scheske](https://publiccode.net/team/laura-Scheske.html)
+- [Laura Scheske](https://publiccode.net/team/laura-scheske.html)
 
 ## Update from the Foundation for Public Code
 

--- a/_posts/2020-07-29-notes-from-community-call-16-july-2020.md
+++ b/_posts/2020-07-29-notes-from-community-call-16-july-2020.md
@@ -1,5 +1,5 @@
 ---
-title: "Notes from community call - 16 July 2020"
+title: "16 July 2020 - Foundation for Public Code community call"
 date: 2020-07-29
 author: Jan Ainali
 type: blogpost


### PR DESCRIPTION
Solves #93

Scheduled for Wednesday now, but we can move that if some other time is better.

-----
[View rendered _posts/2020-07-29-notes-from-community-call-16-july-2020.md](https://github.com/publiccodenet/blog/blob/july-16-blogpost/_posts/2020-07-29-notes-from-community-call-16-july-2020.md)