### PR TITLE
Add summer 2020 newsletter

### DIFF
--- a/_posts/2020-12-02-summer-2020-newsletter.md
+++ b/_posts/2020-12-02-summer-2020-newsletter.md
@@ -22,7 +22,7 @@ Welcome to our newsletter, bumper summer edition. Like last summer, many of the 
 ### Codebase stewardship
 
 * We currently have 2 codebases under stewardship: [Signalen](https://publiccode.net/codebases/signalen.html) and [OpenZaak](https://publiccode.net/codebases/openzaak.html). Both codebases are focused on growing their open source communities in 2020.
-* In June, we built a prototype product marketing website fo OpenZaak: <openzaak.org>.
+* In June, we built a prototype product marketing website for OpenZaak: [openzaak.org](https://openzaak.org/).
 * In July, [Felix](https://publiccode.net/team/felix-faassen.html) blogged about his experiences with the OpenZaak market consultation. [Read his blogpost](https://blog.publiccode.net/codebase%20stewardship/2020/07/01/openzaak-market-consultation-workshops.html).
 * Also in July, [Alba](https://twitter.com/Alba_Roza) developed a communications plan for Signalen, finished a 🎥 [video introducing Signalen](https://www.youtube.com/watch?v=I2Z-mRFt3pg), and launched the Signalen communications steering group.
 * Throughout July and August, [Eric](https://publiccode.net/team/eric-herman.html) and [Jan](https://publiccode.net/team/jan-ainali.html) worked with the Signalen and OpenZaak codebase communities to bring the codebases closer to Standard compliance (for example [adding a licence header to each source code file in OpenZaak](https://github.com/open-zaak/open-zaak/pull/672)).
@@ -39,7 +39,7 @@ Welcome to our newsletter, bumper summer edition. Like last summer, many of the 
 * We took advantage of the summer lull to focus on our own maintenance and administration.
 * We reorganized how the Board of Directors gets updates from the Foundation. [Ben](https://publiccode.net/team/ben-cerveny.html), [Boris](https://publiccode.net/team/boris-van-hoytema.html), [Laura](https://publiccode.net/team/laura-scheske.html) and [Claus](https://publiccode.net/team/claus-mullie.html) are now working on a logframe and roadmap so there's more clarity and predictabilty about our goals and how we'll get there. We'll publish these when they're ready.
 * In operations, [Deborah](https://publiccode.net/team/deborah-meibergen.html) has updated our financial forecasting model, upgraded our chat server, launched new tools to support our community (Mailman, Podbean and StreamYard), and has been experimenting with putting Jitsi on a more stable and scalable footing.
-* For communications, [Floris](http://flrs.nl/contact) is producing beautiful new illustrations and we've reorganised the [illustrations repo](https://github.com/publiccodenet/illustrations) so each illustration has better metadata. [Elena](https://publiccode.net/team/elena-findley-de-regt.html) and [Ryan](http://www.angelplasma.net/work/) are working on a refresh of <publiccode.net>.
+* For communications, [Floris](http://flrs.nl/contact) is producing beautiful new illustrations and we've reorganised the [illustrations repo](https://github.com/publiccodenet/illustrations) so each illustration has better metadata. [Elena](https://publiccode.net/team/elena-findley-de-regt.html) and [Ryan](http://www.angelplasma.net/work/) are working on a refresh of [publiccode.net](https://publiccode.net/).
 
 ## Community and public recognition (spreading the word!) 🗣️💃🙌
 

--- a/_posts/2020-12-02-summer-2020-newsletter.md
+++ b/_posts/2020-12-02-summer-2020-newsletter.md
@@ -1,0 +1,67 @@
+---
+title: "Newsletter, summer 2020"
+date: 2020-12-02
+author: Elena Findley-de Regt
+type: blogpost
+excerpt: Our first newsletter, bumper summer edition!
+categories:
+  - News
+---
+# Foundation for Public Code newsletter - summer 2020 
+
+> This newsletter was originally emailed to subscribers on 31 August 2020. [Subscribe to our newsletter](https://forms.gle/gn7wR2Eaxbv5g1BF9) to get the next one via email!
+
+Hello,
+
+Welcome to our newsletter, bumper summer edition. Like last summer, many of the people we work with went on holiday, but that hasn't slowed us down.
+
+🏅 Perfectly timed to get us pumped for summer, we got an Encouragement Award from the Netherlands Internet Society (as part of their annual Innovation Award) in June. [Read more on our blog](https://blog.publiccode.net/news/2020/06/17/isoc-encouragement-award-consider-us-encouraged.html).
+
+## What we've been up to 👩‍💻 🧑🏻‍🤝‍🧑🏽 🤙
+
+### Codebase stewardship
+
+* We currently have 2 codebases under stewardship: [Signalen](https://publiccode.net/codebases/signalen.html) and [OpenZaak](https://publiccode.net/codebases/openzaak.html). Both codebases are focused on growing their open source communities in 2020.
+* In June, we built a prototype product marketing website fo OpenZaak: <openzaak.org>.
+* In July, [Felix](https://publiccode.net/team/felix-faassen.html) blogged about his experiences with the OpenZaak market consultation. [Read his blogpost](https://blog.publiccode.net/codebase%20stewardship/2020/07/01/openzaak-market-consultation-workshops.html).
+* Also in July, [Alba](https://twitter.com/Alba_Roza) developed a communications plan for Signalen, finished a 🎥 [video introducing Signalen](https://www.youtube.com/watch?v=I2Z-mRFt3pg), and launched the Signalen communications steering group.
+* Throughout July and August, [Eric](https://publiccode.net/team/eric-herman.html) and [Jan](https://publiccode.net/team/jan-ainali.html) worked with the Signalen and OpenZaak codebase communities to bring the codebases closer to Standard compliance (for example [adding a licence header to each source code file in OpenZaak](https://github.com/open-zaak/open-zaak/pull/672)).
+* In August, we hosted the Signalen Community Day Online with the VNG (Dutch Association of Municipalities), attended by current Signalen users and contributors plus cities interested in using it in the future 🏙️🏙️. The workshop had 2 focuses:  strengthening Signalen's product management and integrating Signalen into existing IT infrastructure. The output was the creation of product steering group and a prioritized feature backlog.
+
+### Members
+
+* We're currently in active membership negotiations with 🌍 2 cities, 1 province and 1 national government (in 2 countries).
+* Despite the holidays, we had initial conversations with 2 cities and 1 national government (in 3 more countries).
+* People have started to reach out to us again after their holidays, and we are ready 💪💪.
+
+### Running the Foundation
+
+* We took advantage of the summer lull to focus on our own maintenance and administration.
+* We reorganized how the Board of Directors gets updates from the Foundation. [Ben](https://publiccode.net/team/ben-cerveny.html), [Boris](https://publiccode.net/team/boris-van-hoytema.html), [Laura](https://publiccode.net/team/laura-scheske.html) and [Claus](https://publiccode.net/team/claus-mullie.html) are now working on a logframe and roadmap so there's more clarity and predictabilty about our goals and how we'll get there. We'll publish these when they're ready.
+* In operations, [Deborah](https://publiccode.net/team/deborah-meibergen.html) has updated our financial forecasting model, upgraded our chat server, launched new tools to support our community (Mailman, Podbean and StreamYard), and has been experimenting with putting Jitsi on a more stable and scalable footing.
+* For communications, [Floris](http://flrs.nl/contact) is producing beautiful new illustrations and we've reorganised the [illustrations repo](https://github.com/publiccodenet/illustrations) so each illustration has better metadata. [Elena](https://publiccode.net/team/elena-findley-de-regt.html) and [Ryan](http://www.angelplasma.net/work/) are working on a refresh of <publiccode.net>.
+
+## Community and public recognition (spreading the word!) 🗣️💃🙌
+
+* We've been included in the Swedish [open data knowledge sharing wiki](https://gitlab.com/open-data-knowledge-sharing/wiki/-/wikis/Standard-for-Public-Code) and the EU's Open Source Observatory's [resource catalog](https://joinup.ec.europa.eu/collection/open-source-observatory-osor/specific-resources#section-32).
+* Our August [Standard for Public Code community call](https://blog.publiccode.net/community%20call/2020/08/24/notes-from-community-call-6-august-2020.html) on internationalization had the most participants we've had yet at a community call - 11 participants from 5 countries! We host [monthly community calls](https://about.publiccode.net/activities/community-calls/) for both the Standard and the Foundation for Public Code.
+* Laura presented on codebase stewardship at [Barcamp: Verwaltung. Digital. Gestalten](https://www.fokus.fraunhofer.de/de/dps/barcamp_200820), hosted by the Fraunhofer Institute for Open Communication Systems and NextNetz.
+* 👩‍🎤👨‍🎤 We're launching our podcast [Let's talk public code](https://twitter.com/publiccodenet/status/1300406171334062080) on September 8 - we're very excited for our first guest, and think you'll be too.
+* Boris is giving a talk at State of the Source on why open source is different in government on 10 September - [you can still sign up](https://opensource.org/StateOfTheSource)
+
+## Reading list 📖🕶️⛱️
+
+We're recently enjoyed reading:
+
+* Nadia Eghbal's [Working in Public: The Making and Maintenance of Open Source Software](https://nayafia.substack.com/p/22-working-in-public)
+* Christina Dunbar-Hester's [Hacking Diversity: The Politics of Inclusion in Open Technology Cultures](https://press.princeton.edu/books/paperback/9780691192888/hacking-diversity)
+* The New America Foundation's [Building and Reusing Open Source Tools for Government](https://www.newamerica.org/digital-impact-governance-initiative/reports/building-and-reusing-open-source-tools-government/)
+* the [Ethical Explorer](https://ethicalexplorer.org/) - a toolkit for identifying the downsides of your new technology
+
+We hope you've found some way to have a break this summer, and are entering the autumn recharged.
+
+This is our first newsletter, so please [get in touch](https://about.publiccode.net/organization/contact-details.html) 📨 with any feedback or questions - we're always excited to hear from you.
+
+Until next time,
+
+Elena


### PR DESCRIPTION
This is the same text that was sent to newsletter subscribers in August 2020.

-----
[View rendered _posts/2020-12-02-summer-2020-newsletter.md](https://github.com/publiccodenet/blog/blob/summer-2020-newsletter/_posts/2020-12-02-summer-2020-newsletter.md)