### PR TITLE
ignore 5xx HTTP error codes

### DIFF
--- a/script/test.sh
+++ b/script/test.sh
@@ -9,10 +9,11 @@ bundle exec jekyll build
 # ignore edit links to GitHub as they might not exist yet and
 # set an extra long timout for test-servers with poor connectivity
 # ignore request rate limit errors (HTTP 429) which often come from Twitter or GitHub
+# ignore HTTP 500 series error codes as the are mostly temporary
 # using the files in Jekylls build folder
 bundle exec htmlproofer \
     --assume-extension \
     --url-ignore "/github.com/,/twitter.com/,/opensource.pleio.nl/,/govtechday.se/" \
     --typhoeus-config '{"timeout":60,"ssl_verifypeer":false,"ssl_verifyhost":"0"}' \
-    --http_status_ignore "429" \
+    --http_status_ignore "429", "5xx" \
     ./_site

--- a/script/test.sh
+++ b/script/test.sh
@@ -9,11 +9,11 @@ bundle exec jekyll build
 # ignore edit links to GitHub as they might not exist yet and
 # set an extra long timout for test-servers with poor connectivity
 # ignore request rate limit errors (HTTP 429) which often come from Twitter or GitHub
-# ignore HTTP 500 series error codes as the are mostly temporary
+# ignore HTTP 500 until 504 series error codes as the are mostly temporary or network related issues
 # using the files in Jekylls build folder
 bundle exec htmlproofer \
     --assume-extension \
     --url-ignore "/github.com/,/twitter.com/,/opensource.pleio.nl/,/govtechday.se/" \
     --typhoeus-config '{"timeout":60,"ssl_verifypeer":false,"ssl_verifyhost":"0"}' \
-    --http_status_ignore "429,5xx" \
+    --http_status_ignore "429,500,501,502,503,504" \
     ./_site

--- a/script/test.sh
+++ b/script/test.sh
@@ -15,5 +15,5 @@ bundle exec htmlproofer \
     --assume-extension \
     --url-ignore "/github.com/,/twitter.com/,/opensource.pleio.nl/,/govtechday.se/" \
     --typhoeus-config '{"timeout":60,"ssl_verifypeer":false,"ssl_verifyhost":"0"}' \
-    --http_status_ignore "429", "5xx" \
+    --http_status_ignore "429,5xx" \
     ./_site


### PR DESCRIPTION
500 code series are mostly temporary. This is a fix until we have transitioned towards GH actions and separated link checking process. NOTE: Links are still being checked!