### PR TITLE
Add March 2021 newsletter

### DIFF
--- a/_posts/2021-04-08-March-2021-newsletter.md
+++ b/_posts/2021-04-08-March-2021-newsletter.md
@@ -1,0 +1,78 @@
+---
+title:  "Newsletter: March 2021"
+date: 2021-04-08
+author: Elena Findley-de Regt
+type: blogpost
+excerpt: We've switched to a monthly newsletter!
+category: news
+---
+
+# Newsletter: March 2021
+
+> This is the newsletter sent to our subscribers. [Sign up](https://forms.gle/gn7wR2Eaxbv5g1BF9) to get this in your inbox.
+
+Welcome to our March newsletter. Our 🎉 🎉 highlights this month were:
+
+1. The city of ['s Hertogenbosch is now using Signalen](https://www.vngrealisatie.nl/nieuws/gemeente-s-hertogenbosch-live-met-signalen), making it the 2nd city after Amsterdam to rely on Signalen for core functions. This is only possible due to the community's dedication to making Signalen more easily reusable in the last year.
+2. We published our operations handbook! [Explore how we manage](https://about.publiccode.net/activities/) our finances, procurement, office, tools, staff, and staff information.
+3. We released version [0.2.1 of the Standard for Public Code](https://standard.publiccode.net/) - [see what's changed](https://github.com/publiccodenet/standard/releases/tag/0.2.1).
+
+## Codebase stewardship
+
+We have 3 codebases under stewardship: [Signalen](https://publiccode.net/codebases/signalen.html), [OpenZaak](https://publiccode.net/codebases/openzaak.html) and [Omgevingsbeleid](https://github.com/publiccodenet/publiccode.net/pull/182).
+
+The codebase stewards also met with 4 new codebases to explore potential future stewardship in March.
+
+### Signalen
+
+[Signalen hosted their 2nd community day](https://signalen.org/news/2021-03-29-verslag-community-meetup/) on 22 March, attracting over 55 potential replicators and vendors.
+
+There's increasing international interest in Signalen - Ghent (Belgium) joined the community day, and Helsingborg (Sweden) is testing a demo version.
+
+Signalen moved closer to Standard for Public Code compliance by fully meeting the criteria [Publish with an open license](https://standard.publiccode.net/criteria/open-licenses.html).
+
+### OpenZaak
+
+The OpenZaak community is consolidating healthy community practices. This month they set up a mailing list for upcoming early release notices, and started planning a retro on the [market consultation held last year](https://blog.publiccode.net/codebase%20stewardship/2020/07/01/openzaak-market-consultation-workshops.html). The technical steering team also pruned the backlog; based on this, the product steering team will now decide what to prioritize for procurement and development.
+
+### Omgevingsbeleid
+
+The codebase stewards and Omgevingsbeleid team are designing workshops on essential skills for open technical and product management of a public codebase.
+
+## Members and membership
+
+We're exploring how to help current members be more closely involved in the Foundation for Public Code's governance.
+
+We had potential membership discussions with 3 national governments and 2 cities.
+
+## Board of Directors
+
+Two members of our board have resigned. We're enormously grateful to Arnout Schuijff and Pieter van der Does for their support and hard work over the years.
+
+We'll share more about our search for new board members soon.
+
+## Running the Foundation for Public Code
+
+Our Operations Coordinator Deborah Meibergen gave an introduction to our operations at our March Foundation for Public Code community call - [watch the livestream](https://www.youtube.com/watch?v=LTW9Ye-pofs&t=103s).
+
+We're hard at work on our annual report and community tools that will be ready in April.
+
+## Outreach
+
+We had lots of interesting discussions in March. Check out:
+
+* our podcast [Let's talk about public code, episode 4](https://www.youtube.com/watch?v=5iq1Mqwah7g) with Lea Hemetsberger from Open & Agile Smart Cities, on how they collaborate with cities worldwide to support their digital transformation journey
+* the notes from our [March Standard for Public Code Community call](https://blog.publiccode.net/community%20call/2021/03/16/notes-from-community-call-4-march-2021.html) on how to help people be more confident in using the Standard
+* our co-founder Boris van Hoytema's panel discussion on [smarter, more ethical procurement of open source software in the education, medical, press and government sectors](https://publicspaces.net/timetable/event/aanbod-en-vraag-op-elkaar-afstemmen/) (in Dutch)
+* a [short video about the Governance Game](https://www.youtube.com/watch?v=Dt0WFla4eeM) our codebase steward Jan Ainali created for Mozilla Festival
+
+We also ran sessions at Mozilla Festival on [how public code can transform the future of cities](https://schedule.mozillafestival.org/session/TDHQ3D-1) and [how individuals can affect their government's technology choices](https://schedule.mozillafestival.org/session/CSH7RM-1).
+
+## Upcoming community calls
+
+We'd love to see you at our monthly community calls:
+
+* [Standard for Public Code call](https://hackmd.io/-OegeqvoThCbAsw3c3gIjw), 1st Thursday of the month, 15.00 CEST
+* [Foundation for Public Code call](https://hackmd.io/9THmWbpQTLi8L9UIzczSyw), 3rd Thursday of the month, 15.00 CEST
+
+The topic is published the week before the call.


### PR DESCRIPTION
I've left the old Google sign up link for now - if this is merged after #176, then this needs to be updated to the new Odoo link.

-----
[View rendered _posts/2021-04-08-March-2021-newsletter.md](https://github.com/publiccodenet/blog/blob/March-2021-newsletter/_posts/2021-04-08-March-2021-newsletter.md)