### PR TITLE
Create Signalen Community Meetup blogpost

### DIFF
--- a/_posts/2021-04-09-three-ways-we-supported-the-past-signalen-community-meetup.md
+++ b/_posts/2021-04-09-three-ways-we-supported-the-past-signalen-community-meetup.md
@@ -28,7 +28,7 @@ For the meetup, the Signalen community offered newcomers a prepared demo environ
 
 For a while now the Signalen community has used Jitsi for their regular calls and steering groups and it works just fine, and so it was the chosen tool for the several breakout rooms in the event. 
 
-The machine (hosted in the Foundation for Public Code’s server) did its job well: there were moments with more than 50 attendees in a room, all with good connections.
+The machine (hosted on the Foundation for Public Code server) enabled a day with peaks of more than 50 connected attendees.
 
 ## Moderation of market parties track
 

--- a/_posts/2021-04-09-three-ways-we-supported-the-past-signalen-community-meetup.md
+++ b/_posts/2021-04-09-three-ways-we-supported-the-past-signalen-community-meetup.md
@@ -1,0 +1,45 @@
+---
+title: "Three ways we supported the past Signalen Community Meetup"
+date: 2021-04-09
+author: Alba Roza
+type: blogpost
+excerpt: Organizing a virtual event with the Signalen community
+categories:
+  - Signalen
+---
+
+# Three ways we supported the past Signalen Community Meetup
+
+Last March 22 one of the codebases we are working with, the Dutch [Signalen](signalen.org), organized its first Community Meetup. The aim of this virtual get together was to get to know new municipalities curious about the solution for nuisance reporting as well as vendors interested in its implementation.
+
+As part of its community, the Foundation for Public Code helped advising on mostly three aspects:
+
+## Open Source tools
+
+To this day, Dutch civil servants still work primarily with the tools of a large American corporation -however things are starting to change. The Signalen Community Meetup was a day to celebrate the success of a public codebase, so why wouldn’t we encourage the use of open technologies to hold the event?
+
+### Eventyay
+
+Following the example of FOSSAsia we decided to use Eventyay for the registration of participants. [Eventyay](https://eventyay.com/) is an open source solution for event organizers that features several options to customize your event with: scheduler, call for papers, sponsors, etc. 
+ 
+For the meetup, the Signalen community was offering newcomers the chance of preparing a demo environment to test Signalen beforehand so it was very important to ask a few questions in the registration process. 
+
+### Jitsi
+
+It’s been a while since the Signalen community uses Jitsi for their regular calls and steering groups and it works just fine, and so it was the chosen tool for the several breakout rooms in the event. 
+
+The machine is hosted in the Foundation for Public Code’s server that did its job: there were moments with more than 50 attendees in a room where the connection did fine.
+
+## Moderation of market parties track
+
+Our codebase steward Felix Faassen was asked to moderate the conversation happening in track 3, the vendors’ one. This virtual room was a crucial one since the purpose of the Signalen Community Meetup was not only onboarding potential new municipalities, but also new companies passionate about replicating the Dutch public code solution. 
+
+Read the [notes in Dutch](https://hackmd.io/@felixfaassen/B1RuQXDV_) that Felix took for more information on track 3.
+
+## Event management tips
+
+Once someone decides an event is taking place, the immediate following step must be its planning. Even though the idea for this event was to keep it relatively small and familiar from the beginning, we wanted it to be perfect. We worked along with the community in Github and in several meetings offering them a content plan, a marketing schedule and a communications one. The promotion campaign also walked along other entities like the Foundation for Public Code and several Dutch forums and organizations in order to boost and reach out to more potential interested attendees.
+
+After the event finished, it is time for the follow up actions coordination, task we're currently supporting.
+
+We also published all the notes from meetup, that are open [here](https://signalen.org/en/news/2021-03-29-notes-community-meetup/)

--- a/_posts/2021-04-09-three-ways-we-supported-the-past-signalen-community-meetup.md
+++ b/_posts/2021-04-09-three-ways-we-supported-the-past-signalen-community-meetup.md
@@ -1,5 +1,5 @@
 ---
-title: "Three ways we supported the past Signalen Community Meetup"
+title: "Three ways we supported the last Signalen community meetup"
 date: 2021-04-09
 author: Alba Roza
 type: blogpost
@@ -8,38 +8,38 @@ categories:
   - Signalen
 ---
 
-# Three ways we supported the past Signalen Community Meetup
+# Three ways we supported the last Signalen community meetup
 
-Last March 22 one of the codebases we are working with, the Dutch [Signalen](signalen.org), organized its first Community Meetup. The aim of this virtual get together was to get to know new municipalities curious about the solution for nuisance reporting as well as vendors interested in its implementation.
+On 22 March, one of the codebases we work with, the Dutch [Signalen](https://signalen.org/), organized its first community meetup. The aim of this virtual get together was to get to know new municipalities curious about the solution for nuisance reporting as well as vendors interested in its implementation.
 
-As part of its community, the Foundation for Public Code helped advising on mostly three aspects:
+As part of its community, the Foundation for Public Code helped by advising on mostly three aspects.
 
 ## Open Source tools
 
-To this day, Dutch civil servants still work primarily with the tools of a large American corporation -however things are starting to change. The Signalen Community Meetup was a day to celebrate the success of a public codebase, so why wouldn’t we encourage the use of open technologies to hold the event?
+To this day, Dutch civil servants still work primarily with the tools of a large American corporation - however things are starting to change. The Signalen community meetup was a day to celebrate the success of a public codebase, so why wouldn’t we encourage the use of open technologies to hold the event?
 
 ### Eventyay
 
-Following the example of FOSSAsia we decided to use Eventyay for the registration of participants. [Eventyay](https://eventyay.com/) is an open source solution for event organizers that features several options to customize your event with: scheduler, call for papers, sponsors, etc. 
+Following the example of FOSSAsia we decided to use Eventyay for the registration of participants. [Eventyay](https://eventyay.com/) is an open source solution for event organizers that features several options to customize your event, including a scheduler, call for papers, sponsors, etc. 
  
-For the meetup, the Signalen community was offering newcomers the chance of preparing a demo environment to test Signalen beforehand so it was very important to ask a few questions in the registration process. 
+For the meetup, the Signalen community offered newcomers a prepared demo environment to test Signalen beforehand, so it was very important to ask a few questions during the registration process. 
 
 ### Jitsi
 
-It’s been a while since the Signalen community uses Jitsi for their regular calls and steering groups and it works just fine, and so it was the chosen tool for the several breakout rooms in the event. 
+For a while now the Signalen community has used Jitsi for their regular calls and steering groups and it works just fine, and so it was the chosen tool for the several breakout rooms in the event. 
 
-The machine is hosted in the Foundation for Public Code’s server that did its job: there were moments with more than 50 attendees in a room where the connection did fine.
+The machine (hosted in the Foundation for Public Code’s server) did its job well: there were moments with more than 50 attendees in a room, all with good connections.
 
 ## Moderation of market parties track
 
 Our codebase steward Felix Faassen was asked to moderate the conversation happening in track 3, the vendors’ one. This virtual room was a crucial one since the purpose of the Signalen Community Meetup was not only onboarding potential new municipalities, but also new companies passionate about replicating the Dutch public code solution. 
 
-Read the [notes in Dutch](https://hackmd.io/@felixfaassen/B1RuQXDV_) that Felix took for more information on track 3.
+[Read Felix's notes](https://hackmd.io/@felixfaassen/B1RuQXDV_) (in Dutch) for more information on track 3.
 
 ## Event management tips
 
 Once someone decides an event is taking place, the immediate following step must be its planning. Even though the idea for this event was to keep it relatively small and familiar from the beginning, we wanted it to be perfect. We worked along with the community in Github and in several meetings offering them a content plan, a marketing schedule and a communications one. The promotion campaign also walked along other entities like the Foundation for Public Code and several Dutch forums and organizations in order to boost and reach out to more potential interested attendees.
 
-After the event finished, it is time for the follow up actions coordination, task we're currently supporting.
+After the event finished, it is time for the follow up actions coordination, a task we're currently supporting.
 
-We also published all the notes from meetup, that are open [here](https://signalen.org/en/news/2021-03-29-notes-community-meetup/)
+[We also published all public notes from the meet up](https://signalen.org/en/news/2021-03-29-notes-community-meetup/).

--- a/_posts/2021-04-09-three-ways-we-supported-the-past-signalen-community-meetup.md
+++ b/_posts/2021-04-09-three-ways-we-supported-the-past-signalen-community-meetup.md
@@ -10,7 +10,7 @@ categories:
 
 # Three ways we supported the last Signalen community meetup
 
-On 22 March, one of the codebases we work with, the Dutch [Signalen](https://signalen.org/), organized its first community meetup. The aim of this virtual get together was to get to know new municipalities curious about the solution for nuisance reporting as well as vendors interested in its implementation.
+On 22 March, one of the codebases we work with, the Dutch [Signalen](https://signalen.org/), organized its first public community meetup. The aim of this virtual get together was to get to know new municipalities curious about the solution for nuisance reporting as well as vendors interested in its implementation.
 
 As part of its community, the Foundation for Public Code helped by advising on mostly three aspects.
 
@@ -38,7 +38,7 @@ Our codebase steward Felix Faassen was asked to moderate the conversation happen
 
 ## Event management tips
 
-Once someone decides an event is taking place, the immediate following step must be its planning. Even though the idea for this event was to keep it relatively small and familiar from the beginning, we wanted it to be perfect. We worked along with the community in Github and in several meetings offering them a content plan, a marketing schedule and a communications one. The promotion campaign also walked along other entities like the Foundation for Public Code and several Dutch forums and organizations in order to boost and reach out to more potential interested attendees.
+Once someone decides an event is taking place, the immediate following step must be its planning. Even though the idea for this event was to keep it relatively small and intimate from the beginning, we wanted it to be perfect. We worked along with the community in Github and in several meetings offering them a content plan, a marketing schedule and a communications one. The promotion campaign also walked along other entities like the Foundation for Public Code and several Dutch forums and organizations in order to boost and reach out to more potential interested attendees.
 
 After the event finished, it is time for the follow up actions coordination, a task we're currently supporting.
 

--- a/_posts/2021-04-09-three-ways-we-supported-the-past-signalen-community-meetup.md
+++ b/_posts/2021-04-09-three-ways-we-supported-the-past-signalen-community-meetup.md
@@ -38,7 +38,7 @@ Our codebase steward Felix Faassen was asked to moderate the conversation happen
 
 ## Event management tips
 
-Once someone decides an event is taking place, the immediate following step must be its planning. Even though the idea for this event was to keep it relatively small and intimate from the beginning, we wanted it to be perfect. We worked along with the community in Github and in several meetings offering them a content plan, a marketing schedule and a communications one. The promotion campaign also walked along other entities like the Foundation for Public Code and several Dutch forums and organizations in order to boost and reach out to more potential interested attendees.
+Once someone decides an event is taking place, the immediate following step must be its planning. Even though the idea for this event was to keep it relatively small and intimate from the beginning, we wanted it to be perfect. We worked along with the community in Github and in several meetings offering them a content plan, a marketing schedule and a communications one. The promotion campaign also brought along other entities like the Foundation for Public Code and several Dutch forums and organizations in order to boost and reach out to more potential interested attendees.
 
 After the event finished, it is time for the follow up actions coordination, a task we're currently supporting.
 

--- a/_posts/2021-04-09-three-ways-we-supported-the-past-signalen-community-meetup.md
+++ b/_posts/2021-04-09-three-ways-we-supported-the-past-signalen-community-meetup.md
@@ -32,7 +32,7 @@ The machine (hosted on the Foundation for Public Code server) enabled a day with
 
 ## Moderation of market parties track
 
-Our codebase steward Felix Faassen was asked to moderate the conversation happening in track 3, the vendors’ one. This virtual room was a crucial one since the purpose of the Signalen Community Meetup was not only onboarding potential new municipalities, but also new companies passionate about replicating the Dutch public code solution. 
+Our codebase steward Felix Faassen was asked to moderate the conversation happening in track 3, the vendors’ one. This virtual room was a crucial one since the purpose of the Signalen community meetup was not only onboarding potential new municipalities, but also new companies passionate about replicating the Dutch public code solution. 
 
 [Read Felix's notes](https://hackmd.io/@felixfaassen/B1RuQXDV_) (in Dutch) for more information on track 3.
 


### PR DESCRIPTION
Blogpost with three ways we supported the past Signalen Community Meetup.

-----
[View rendered _posts/2021-04-09-three-ways-we-supported-the-past-signalen-community-meetup.md](https://github.com/publiccodenet/blog/blob/signalen-meetup/_posts/2021-04-09-three-ways-we-supported-the-past-signalen-community-meetup.md)