### PR TITLE
Ignore linkedin.com URLs in linkcheck

### DIFF
--- a/script/test-with-link-check.sh
+++ b/script/test-with-link-check.sh
@@ -17,14 +17,22 @@ set -e # halt script on error
 bundle exec jekyll build
 
 # Check for broken links and missing alt tags:
-# jekyll does not require extentions like HTML
-# ignore edit links to GitHub as they might not exist yet
+# --assume-extension: jekyll does not require extentions like HTML
+# --url-ignore:
+# * edit links to GitHub as they might not exist yet
+# * twitter.com - HTTP 200, but content "doesn't exist"
+# * listennotes.com - HTTP 403
+# * linkedin.com - HTTP 999, (really!) gives login page
+# --typhoeus-config:
 # set an extra long timout for test-servers with poor connectivity
-# ignore request rate limit errors (HTTP 429)
-# using the files in Jekylls build folder
+# skip ssl certificate checking
+# --http_status_ignore
+# * request rate limit errors (HTTP 429)
+# * server errors (HTTP 5xx)
+# using the files in Jekyll's build folder "./_site"
 bundle exec htmlproofer \
     --assume-extension \
-    --url-ignore "/github.com/(.*)/edit/,/twitter.com/,/listennotes\.com/" \
+    --url-ignore "/github.com/(.*)/edit/,/twitter.com/,/listennotes\.com/,/linkedin\.com/" \
     --typhoeus-config '{"timeout":60,"ssl_verifypeer":false,"ssl_verifyhost":"0"}' \
     --http_status_ignore "429,500,501,502,503,504" \
     ./_site


### PR DESCRIPTION
The site linkedin.com returns HTTP status code "999" ... even though
there is no HTTP class "900" nor any standard meaning for status 999.

A support issue has been raised with LinkedIn, their response is that
it has been acknowledged by their product team, but no timeline can
be provided based upon priority. From the response, it seems fair to
conclude that the issue will languish on their backlog.

This patch documents the --url-ignore option which ignores these
links as well as the other htmlproofer commandline arguments.