### PR TITLE
fix strategic-council link

### DIFF
--- a/_posts/2021-09-13-launching-our-strategic-council.md
+++ b/_posts/2021-09-13-launching-our-strategic-council.md
@@ -23,4 +23,4 @@ There are additional appointments underway.
 
 ## Further reading
 
-[Read more about the strategic council](about.publiccode.net/organization/strategic-council.html) and the appointment process.
+[Read more about the strategic council](https://about.publiccode.net/organization/strategic-council.html) and the appointment process.


### PR DESCRIPTION
(was missing "https://" which *works* but isn't correct)

-----
[View rendered _posts/2021-09-13-launching-our-strategic-council.md](https://github.com/publiccodenet/blog/blob/eh-fix-link-20210915/_posts/2021-09-13-launching-our-strategic-council.md)