### PR TITLE
Release 20211109

### DIFF
--- a/_posts/2021-11-08-types-of-codebases-to-strategically-steward.md
+++ b/_posts/2021-11-08-types-of-codebases-to-strategically-steward.md
@@ -1,0 +1,53 @@
+---
+title: "Types of codebases to strategically steward"
+date: 2021-11-08
+author: Jan Ainali
+type: blogpost
+excerpt: What are the kinds of codebases we want to steward directly?
+categories:
+  - News
+---
+
+# Types of codebases to strategically steward
+
+Last week we published the [end-of-year goals for the codebase stewards](https://blog.publiccode.net/news/2021/11/03/stewards-end-of-year-goals.html) as a result of our new [roadmap](https://about.publiccode.net/organization/roadmap.html).
+One of the goals was "Make a wish list of types of codebases we desire for direct stewardship" and comes from our notion that we instead if directly stewarding all the thousands of public codebases there is we should use a distributed model.
+Whilst doing that we still want to directly steward some key codebases.
+These would be the ones that become the standards in their respective public domains and that have the potential to be key global infrastructure.
+
+So we thought we could start early and make a wish list of types of codebases we desire for direct stewardship.
+We have a few ideas, and now we want you to chime in. Our goal is to define some categories/types that we should pursue strategically.
+Below is a draft list, containing kinds of codebases we think will play a key role.
+As you see, there are still some open questions in it, so it is in no means a final version (you can think of it being version 0.1).
+Please do give feedback to us in [this issue](https://github.com/publiccodenet/about/issues/1013).
+Even if you just agree, please give it a thumbs up, but if you think we missed something or that something does not qualify, please leave a comment.
+
+- Legislation and policy making
+  - Public budgeting
+- Participatory democracy
+- Border control / refugee support
+- Climate change
+- Public information / transparency
+  - Algorithm registers
+  - Open source software catalogs
+  - Open Data portals
+  - Something for public records / minutes / archive / freedom of information portal?
+- Residents and citizens
+  - Digital identification
+  - Civil registration and vital statistics
+- City nuisance reports
+- Something voting related?
+
+In the list below, we are not as sure that we need to steward them all directly, but we also recognize that in many countries they do play a key role.
+Please also give us your thoughts about these.
+
+- Health
+  - Health Information Systems
+  - Medical Records Systems
+- Education
+- Social security
+- (Municipal) (front end) case management
+- Government focused Linux distribution?
+
+Again, we publish this draft because we want your feedback.
+Please, [give it here](https://github.com/publiccodenet/about/issues/1013).

--- a/_posts/2021-11-09-notes-from-community-call-4-november-2021.md
+++ b/_posts/2021-11-09-notes-from-community-call-4-november-2021.md
@@ -1,0 +1,58 @@
+---
+title: "Notes from the Standard for Public Code community call - 4 November 2021"
+date: 2021-11-09
+author: Jan Ainali
+type: blogpost
+excerpt: Glossary and more about non-English terms
+categories:
+  - Community call
+---
+
+# Notes from the Standard for Public Code community call - 4 November 2021
+
+## Attendees
+
+* [Jan Ainali](https://publiccode.net/team/jan-ainali.html)
+* [Eric Herman](https://publiccode.net/team/eric-herman.html)
+* [Charlotte Heikendorf](https://os2.eu/bruger/charlotte-heikendorf), OS2
+
+## Updates from the Foundation
+
+* We have [launched a strategic council](https://blog.publiccode.net/news/2021/09/13/launching-our-strategic-council.html)
+* Dan Hill is [joining us in our strategic council](https://about.publiccode.net/organization/strategic-council.html)
+* Signalen is [live in a third municipality](https://meldingen.alphenaandenrijn.nl/)
+* We will start hosting (unofficial) [community translations](https://github.com/publiccodenet/community-translations-standard) of the Standard for Public Code
+
+## Glossary
+
+### Background
+
+In the Standard for Public Code, we talk about contexts without really defining it.
+We would like to get more input before we [create a glossary term](https://github.com/publiccodenet/standard/issues/529).
+
+### Notes
+
+We agreed that even though there was some notion of what it might mean, the term was ambiguous enugh to deserve a clarification.
+After some discussion, this is our proposal for the glossary:
+
+**Different contexts** - two contexts are different if they are different public organizations or different departments for which there is not one decision maker that could make collaboration happen naturally.
+
+## Non-english
+
+### Background
+
+In our [community call in September](https://blog.publiccode.net/community%20call/2021/09/08/notes-from-community-call-2-september-2021.html), we talked about non-English terms.
+We have had a discussion in the ongoing pull requests and would like to make a final check before merging them.
+- [Issue #223: Add nuance on where non-English is acceptable](https://github.com/publiccodenet/standard/pull/527)
+- [Issue #308: Clarify intersection of policy-defined vocabulary and Use Plain English](https://github.com/publiccodenet/standard/pull/528)
+
+### Notes
+
+We agreed that it would be good to better define what `plain English` means in the Standard for Public Code.
+We agreed to:
+- make a a glossary definition inline with our requirement today (lower secondary education reading level, as recommended by the Web Content Accessibility Guidelines 2)
+- make sure that all places that needs it, uses this term
+- move [the suggested link](https://www.plainlanguage.gov/about/definitions/) to Further reading as it adds value, but isn't specific as a definition
+
+After discussing the new requirement about policy being executed we agreed that using the term `business domain` would open it too wide.
+We also recognized the need for using non-English terms, but that all the relevant use cases that we could see, would in effect be covered by our suggestions.


### PR DESCRIPTION
Adds blog post for the November Standard for Public Code community call

-----
[View rendered _posts/2021-11-09-notes-from-community-call-4-november-2021.md](https://github.com/publiccodenet/blog/blob/release-20211109/_posts/2021-11-09-notes-from-community-call-4-november-2021.md)