### PR TITLE
Release 20211115

### DIFF
--- a/_posts/2021-11-09-notes-from-community-call-4-november-2021.md
+++ b/_posts/2021-11-09-notes-from-community-call-4-november-2021.md
@@ -1,0 +1,58 @@
+---
+title: "Notes from the Standard for Public Code community call - 4 November 2021"
+date: 2021-11-09
+author: Jan Ainali
+type: blogpost
+excerpt: Glossary and more about non-English terms
+categories:
+  - Community call
+---
+
+# Notes from the Standard for Public Code community call - 4 November 2021
+
+## Attendees
+
+* [Jan Ainali](https://publiccode.net/team/jan-ainali.html)
+* [Eric Herman](https://publiccode.net/team/eric-herman.html)
+* [Charlotte Heikendorf](https://os2.eu/bruger/charlotte-heikendorf), OS2
+
+## Updates from the Foundation
+
+* We have [launched a strategic council](https://blog.publiccode.net/news/2021/09/13/launching-our-strategic-council.html)
+* Dan Hill is [joining us in our strategic council](https://about.publiccode.net/organization/strategic-council.html)
+* Signalen is [live in a third municipality](https://meldingen.alphenaandenrijn.nl/)
+* We will start hosting (unofficial) [community translations](https://github.com/publiccodenet/community-translations-standard) of the Standard for Public Code
+
+## Glossary
+
+### Background
+
+In the Standard for Public Code, we talk about contexts without really defining it.
+We would like to get more input before we [create a glossary term](https://github.com/publiccodenet/standard/issues/529).
+
+### Notes
+
+We agreed that even though there was some notion of what it might mean, the term was ambiguous enugh to deserve a clarification.
+After some discussion, this is our proposal for the glossary:
+
+**Different contexts** - two contexts are different if they are different public organizations or different departments for which there is not one decision maker that could make collaboration happen naturally.
+
+## Non-english
+
+### Background
+
+In our [community call in September](https://blog.publiccode.net/community%20call/2021/09/08/notes-from-community-call-2-september-2021.html), we talked about non-English terms.
+We have had a discussion in the ongoing pull requests and would like to make a final check before merging them.
+- [Issue #223: Add nuance on where non-English is acceptable](https://github.com/publiccodenet/standard/pull/527)
+- [Issue #308: Clarify intersection of policy-defined vocabulary and Use Plain English](https://github.com/publiccodenet/standard/pull/528)
+
+### Notes
+
+We agreed that it would be good to better define what `plain English` means in the Standard for Public Code.
+We agreed to:
+- make a a glossary definition inline with our requirement today (lower secondary education reading level, as recommended by the Web Content Accessibility Guidelines 2)
+- make sure that all places that needs it, uses this term
+- move [the suggested link](https://www.plainlanguage.gov/about/definitions/) to Further reading as it adds value, but isn't specific as a definition
+
+After discussing the new requirement about policy being executed we agreed that using the term `business domain` would open it too wide.
+We also recognized the need for using non-English terms, but that all the relevant use cases that we could see, would in effect be covered by our suggestions.

--- a/_posts/2021-11-15-pruning-the-oldest-issues.md
+++ b/_posts/2021-11-15-pruning-the-oldest-issues.md
@@ -1,0 +1,28 @@
+---
+title: "Pruning the oldest issues - November 2021"
+date: 2021-09-13
+author: Jan Ainali
+type: blogpost
+excerpt: Making progress on the navigation
+categories:
+  - Community call
+---
+
+# Pruning the oldest issues - November 2021
+
+## Attendees
+
+* [Jan Ainali](https://publiccode.net/who-we-are/team/jan-ainali.html)
+* [Eric Herman](https://publiccode.net/who-we-are/team/eric-herman.html)
+
+## Notes
+
+We started by reviewing [the notes from the last session](https://blog.publiccode.net/community%20call/2021/09/13/pruning-the-oldest-issues.html) and immediately followed up on the ones needed action.
+
+* [No navigation in web version #217](https://github.com/publiccodenet/standard/issues/217) - we merged [the jekyll-theme pull request for this](https://github.com/publiccodenet/jekyll-theme/pull/74).
+* [Introduction/certifying an entire codebase: unclear paragraph #218](https://github.com/publiccodenet/standard/issues/218) - we talked about this in [the October community call](https://blog.publiccode.net/community%20call/2021/10/11/notes-from-community-call-7-october-2021.html). We will investigate modularity so the refactoring is on hold for now.
+* [Document limitations of a codebase #219](https://github.com/publiccodenet/standard/issues/219) - closed
+* [Recommend responding to issues and pull requests in a timely manner #221](https://github.com/publiccodenet/standard/issues/221) - we forgot to add explicit date so we will revisit by next meeting, close if no new suggestions.
+* [Add engineering guidelines (in addition to Standard criteria 13 - use a coherent style) #222](https://github.com/publiccodenet/standard/issues/222) - stays open, work session planned for November 18.
+
+Then we created a [pull request](https://github.com/publiccodenet/standard/pull/535) for the Standard repository to implement the changes from the jekyll-theme change.


### PR DESCRIPTION
Adds blog post that summarizes the standard backlog pruning session

-----
[View rendered _posts/2021-11-15-pruning-the-oldest-issues.md](https://github.com/publiccodenet/blog/blob/release-20211115/_posts/2021-11-15-pruning-the-oldest-issues.md)