### PR TITLE
Add blog post for strategic codebases

### DIFF
--- a/_posts/2021-12-14-strategic-codebase-types-for-stewardship.md
+++ b/_posts/2021-12-14-strategic-codebase-types-for-stewardship.md
@@ -1,0 +1,45 @@
+---
+title: "Strategic codebase types for stewardship"
+date: 2021-12-14
+author: Jan Ainali
+type: blogpost
+excerpt: The kinds of codebases we want to steward directly
+categories:
+  - News
+---
+
+# Types of codebases to strategically steward
+
+A month ago [we asked for feedback on types of codebases for stewardship](https://blog.publiccode.net/news/2021/11/08/types-of-codebases-to-strategically-steward.html). This is one of our [end-of-year goals for the codebase stewards](https://blog.publiccode.net/news/2021/11/03/stewards-end-of-year-goals.html) which connects to our [roadmap](https://about.publiccode.net/organization/roadmap.html).
+
+We got some feedback, and have been doing some more thinking of our own as well.
+This is why we now can publish a first version of out wish list of types of codebases we desire for direct stewardship.
+Obviously, we hope to learn more over time, so this is not a definitive list for all time.
+Rather we imagine that we will iterate and fine tune this while we are having conversations in our community.
+
+With that, here is our current list:
+
+- Legislation and policy making
+  - Public budgeting
+- Participatory democracy
+- Border control / refugee support
+- Climate change
+- Environmental sciences and biodiversity
+- Public information / transparency
+  - Algorithm registers
+  - Open source software catalogs
+  - Open Data portals
+  - Public records / minutes / freedom of information portal
+  - Long term data and documents archival
+- Residents and citizens
+  - Digital identification
+  - Civil registration and vital statistics
+- City nuisance reports
+- Voting
+- Public transportation
+- Health
+  - Health Information Systems
+  - Medical Records Systems
+- Education
+- Social security
+- (Municipal) (front end) case management


### PR DESCRIPTION
Meant to be published Tuesday, December 14.

Fixes #278

-----
[View rendered _posts/2021-12-14-strategic-codebase-types-for-stewardship.md](https://github.com/publiccodenet/blog/blob/strategic-codebases-v1/_posts/2021-12-14-strategic-codebase-types-for-stewardship.md)