### PR TITLE
Fix broken opensourcelisbon.com/agenda link

### DIFF
--- a/_posts/2021-06-08-newsletter-may-2021.md
+++ b/_posts/2021-06-08-newsletter-may-2021.md
@@ -26,7 +26,7 @@ We're all quite excited about these:
 
 - 10 June: Based on the success of our first Standard backlog pruning call in May, we'll host this regularly on the 2nd Thursday of the month
 - 17 June: Join our regular Foundation for Public Code community call. Please [help us pick the topic](https://github.com/publiccodenet/blog/issues/198) - what would you most like to talk about with us?
-- 17-18 June: Our president Ben Cerveny will be speaking at [Open Source Lisbon](https://www.opensourcelisbon.com/agenda) (Portugal)
+- 17-18 June: Our president Ben Cerveny will be speaking at [Open Source Lisbon](https://www.opensourcelisbon.com/) (Portugal)
 - June 23-30: Our codebase steward Jan Ainali ([@Jan_Ainali](https://twitter.com/jan_ainali)) will host the rotation curated Twitter account [@imakefoss](https://twitter.com/imakefoss)
 - 28 June-2 July: Jan will also be speaking at the [Open Source Summit, 2021](https://web.archive.org/web/20210630211728/https://oss2021.saintgits.org/), hosted by the Open Source Club of Saintgits College of Engineering (India)
 


### PR DESCRIPTION
Seems the Wayback Machine does not have a copy,
thus we can link to the parent site.
This is not as good, but still makes sense.

-----
[View rendered _posts/2021-06-08-newsletter-may-2021.md](https://github.com/publiccodenet/blog/blob/fix-opensourcelisbon-link/_posts/2021-06-08-newsletter-may-2021.md)