### PR TITLE
Fix name typo

### DIFF
--- a/_posts/2022-01-11-notes-from-community-call-6-january-2022.md
+++ b/_posts/2022-01-11-notes-from-community-call-6-january-2022.md
@@ -14,7 +14,7 @@ categories:
 
 * [Jan Ainali](https://publiccode.net/who-we-are/team/jan-ainali.html)
 * [Eric Herman](https://publiccode.net/who-we-are/team/eric-herman.html)
-* [Boris van Hoytema](https://publiccode.net/who-we-are/team/boris-van-hoytmea.html)
+* [Boris van Hoytema](https://publiccode.net/who-we-are/team/boris-van-hoytema.html)
 * [Kehinde Bademosi](https://publiccode.net/who-we-are/team/kehinde-bademosi.html)
 
 ## Updates from the Foundation


### PR DESCRIPTION
It shoudl be "hoytema" not "hoytmea".

-----
[View rendered _posts/2022-01-11-notes-from-community-call-6-january-2022.md](https://github.com/publiccodenet/blog/blob/link-fixes-20220118-a/_posts/2022-01-11-notes-from-community-call-6-january-2022.md)