### PR TITLE
Update GitHub workflow ruby/setup-ruby

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '2.7'
       - run: bundle install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '2.7'
       - run: bundle install


### PR DESCRIPTION
From: https://github.com/publiccodenet/blog/runs/4850722363?check_suite_focus=true
> ```
> Run actions/setup-ruby@v1
>   with:
>     ruby-version: 2.7
> ------------------------
> NOTE: This action is deprecated and is no longer maintained.
> Please, migrate to https://github.com/ruby/setup-ruby, which is being actively maintained.
> ------------------------
> ```