### PR TITLE
Add blog post for January backlog pruning

### DIFF
--- a/_posts/2022-01-20-pruning-the-oldest-issues.md
+++ b/_posts/2022-01-20-pruning-the-oldest-issues.md
@@ -1,0 +1,32 @@
+---
+title: "Pruning the oldest issues - January 2022"
+date: 2022-01-20
+author: Jan Ainali
+type: blogpost
+excerpt: Seven old issues closed
+categories:
+  - Community call
+---
+
+# Pruning the oldest issues - January 2022
+
+## Attendees
+
+* [Jan Ainali](https://publiccode.net/who-we-are/team/jan-ainali.html)
+* [Eric Herman](https://publiccode.net/who-we-are/team/eric-herman.html)
+
+## Notes
+
+We started by reviewing [the notes from the last session](https://blog.publiccode.net/community%20call/2021/11/15/pruning-the-oldest-issues.html) and immediately followed up on the one needed action. 
+
+* [Recommend responding to issues and pull requests in a timely manner #221](https://github.com/publiccodenet/standard/issues/221) - nothing new added, closed.
+* [Add nuance on where non-English is acceptable #223](https://github.com/publiccodenet/standard/issues/223) stays open, work session planned for January 17.
+* ['Bundle policy and source code' can be interpreted very wide #224](https://github.com/publiccodenet/standard/issues/224) - stays open, a pilot is planned.
+* [Missing: the why for each requirement (user stories and success criteria) #229](https://github.com/publiccodenet/standard/issues/229) - closed, superseded by [#560](https://github.com/publiccodenet/standard/issues/560).
+* [Different headings? #230](https://github.com/publiccodenet/standard/issues/230) - closed, superseded by [#560](https://github.com/publiccodenet/standard/issues/560).
+* [Potential new requirement: clean coding #231](https://github.com/publiccodenet/standard/issues/231) - this has been covered by now, closed.
+* [Make this more concise #232](https://github.com/publiccodenet/standard/issues/232) - closed, superseded by [#415](https://github.com/publiccodenet/standard/issues/425).
+* [Require a roadmap #233](https://github.com/publiccodenet/standard/issues/233) - already fixed, closed.
+* [Require an explanation of the codebase governance structure #234](https://github.com/publiccodenet/standard/issues/234) - already fixed, closed.
+* [How does public code fit with existing EU laws? #235](https://github.com/publiccodenet/standard/issues/235) - stays open, a pilot is planned.
+* [Require machine readable API specifications #237](https://github.com/publiccodenet/standard/issues/237) - comment added, check next time.


### PR DESCRIPTION
Fixes #302

Meant to be published on Thursday.

-----
[View rendered _posts/2022-01-20-pruning-the-oldest-issues.md](https://github.com/publiccodenet/blog/blob/jan-backlog-pruning/_posts/2022-01-20-pruning-the-oldest-issues.md)