### PR TITLE
Add blog post for February standard community call

### DIFF
--- a/_posts/2022-02-03-notes-from-community-call-3-february-2022.md
+++ b/_posts/2022-02-03-notes-from-community-call-3-february-2022.md
@@ -36,10 +36,10 @@ This discussion has a long history and several related issues:
 ### Discussion
 
 In this call we started by taking a good look at the suggestions made in [issue #568](https://github.com/publiccodenet/standard/issues/568) which we felt provided a good start for an update of the criterion.
-After some discussion, these valuable input helped us towards the idea that we could make two substantial improvments.
+After some discussion, this valuable input helped us towards the idea that we could make two substantial improvments.
 
 First, we felt the need of expanding on the section "Why this is important", especially since this criterion is what really makes the Standard for Public Code unique.
 
 Then we also recognized the need for an expansion under "Policy makers:	 what you need to do" in order to make it clear that policy, according to our [glossary](https://standard.publiccode.net/glossary.html), has a wider meaning than in the general language.
 
-We ended the call by creating a [draft pull request](https://github.com/publiccodenet/standard/pull/573) with changes to address both these realizations.
+We ended the call by creating a [draft pull request](https://github.com/publiccodenet/standard/pull/573) with changes to partially address both these realizations.

--- a/_posts/2022-02-03-notes-from-community-call-3-february-2022.md
+++ b/_posts/2022-02-03-notes-from-community-call-3-february-2022.md
@@ -1,0 +1,45 @@
+---
+title: "Notes from the Standard for Public Code community call - 3 February 2022"
+date: 2022-02-03
+author: Jan Ainali
+type: blogpost
+excerpt: Expanding on bundling policy and code
+categories:
+  - Community call
+---
+
+# Notes from the Standard for Public Code community call - 3 February 2022
+
+## Attendees
+
+* [Jan Ainali](https://publiccode.net/who-we-are/team/jan-ainali.html)
+* [Eric Herman](https://publiccode.net/who-we-are/team/eric-herman.html)
+
+## Updates from the Foundation
+
+* FOSDEM is this weekend, [check out the schedule](https://fosdem.org/2022/schedule/room/dpublic_code/)
+* We have published the [community translations of the Standard for Public Code](https://publiccodenet.github.io/community-translations-standard/)
+
+## Notes
+
+### Background
+
+Continuing on [our last community call](https://blog.publiccode.net/community%20call/2022/01/11/notes-from-community-call-6-january-2022.html) we want to dig further into how existing policies, laws, regulations and strategies, applicable to and made by a public organization, make demands on codebases developed by them.
+
+This discussion has a long history and several related issues:
+
+* [[Bundle policy and source code] Account to business processes #568](https://github.com/publiccodenet/standard/issues/568)
+* [Require documenting policy in the codebase (as part of 'bundle policy and code') #378](https://github.com/publiccodenet/standard/issues/378)
+* ['Bundle policy and source code' can be interpreted very wide #224](https://github.com/publiccodenet/standard/issues/224)
+* [Bundle policy and code: invite policy makers to contribute their own work in their own formats #62](https://github.com/publiccodenet/standard/issues/62)
+
+### Discussion
+
+In this call we started by taking a good look at the suggestions made in [issue #568](https://github.com/publiccodenet/standard/issues/568) which we felt provided a good start for an update of the criterion.
+After some discussion, these valuable input helped us towards the idea that we could make two substantial improvments.
+
+First, we felt the need of expanding on the section "Why this is important", especially since this criterion is what really makes the Standard for Public Code unique.
+
+Then we also recognized the need for an expansion under "Policy makers:	 what you need to do" in order to make it clear that policy, according to our [glossary](https://standard.publiccode.net/glossary.html), has a wider meaning than in the general language.
+
+We ended the call by creating a [draft pull request](https://github.com/publiccodenet/standard/pull/573) with changes to address both these realizations.


### PR DESCRIPTION
To publish as soon as possible.

Fixes #314

-----
[View rendered _posts/2022-02-03-notes-from-community-call-3-february-2022.md](https://github.com/publiccodenet/blog/blob/feb-standard-community-call/_posts/2022-02-03-notes-from-community-call-3-february-2022.md)