### PR TITLE
Include top-level pages for jekyll

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,6 +8,9 @@ plugins:
 
 # Also render the README to HTML even if there is an index.md
 include:
+  - CONTRIBUTING.md
+  - index.md
+  - LICENSE.md
   - README.md
 
 # Exclude the `vendor` folder created by Travis


### PR DESCRIPTION
Fixes the dead-links to the /LICENSE.html and similar.

See: https://github.com/publiccodenet/blog/runs/5193876168