### PR TITLE
Fix crontab minutes

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -10,7 +10,7 @@ on:
 #             │ │ │ │ │
 #             │ │ │ │ │
 #             * * * * *
-    - cron:  '* 1 * * *' # every day at 01:00 (UTC?)
+    - cron:  '7 1 * * *' # every day at 01:07 (UTC?)
 
 defaults:
   run:


### PR DESCRIPTION
While the infrastructure is smart enough to avoid the mistake,
the schedule implies run every minute during the first hour.
This now picks a specific minute upon which to run the event.