### PR TITLE
Add blogpost for March backlog pruning session

### DIFF
--- a/_posts/2022-03-11-pruning-the-oldest-issues.md
+++ b/_posts/2022-03-11-pruning-the-oldest-issues.md
@@ -1,0 +1,27 @@
+---
+title: "Pruning the oldest issues - March 2022"
+date: 2022-03-11
+author: Jan Ainali
+type: blogpost
+excerpt: Two issues addressed
+categories:
+  - Community call
+---
+
+# Pruning the oldest issues - March 2022
+
+## Attendees
+
+* [Jan Ainali](https://publiccode.net/who-we-are/team/jan-ainali.html)
+* [Eric Herman](https://publiccode.net/who-we-are/team/eric-herman.html)
+
+## Notes
+
+We reviewed [the notes from the last session](https://blog.publiccode.net/community%20call/2022/01/20/pruning-the-oldest-issues.html) and had one outstanding issue:
+
+- [Require machine readable API specifications #237](https://github.com/publiccodenet/standard/issues/237)
+    - We made a [pull request](https://github.com/publiccodenet/standard/pull/583) that adds further reading
+
+Then we looked at the open pull request:
+
+-[Expand Bundle policy and code to clearly include processes #573](https://github.com/publiccodenet/standard/pull/573) and made some improvements of the language (without changing the substance of the pull request)


### PR DESCRIPTION
To be published Friday

-----
[View rendered _posts/2022-03-11-pruning-the-oldest-issues.md](https://github.com/publiccodenet/blog/blob/backlog-pruning-march/_posts/2022-03-11-pruning-the-oldest-issues.md)