### PR TITLE
Add blog post for April pruning session

### DIFF
--- a/_posts/2022-04-21-pruning-the-oldest-issues.md
+++ b/_posts/2022-04-21-pruning-the-oldest-issues.md
@@ -1,0 +1,34 @@
+---
+title: "Pruning the oldest issues - April 2022"
+date: 2022-04-21
+author: Jan Ainali
+type: blogpost
+excerpt: Three issues closed, five work sessions planned
+categories:
+  - Community call
+---
+
+# Pruning the oldest issues - March 2022
+
+## Attendees
+
+* [Jan Ainali](https://publiccode.net/who-we-are/team/jan-ainali.html)
+* [Eric Herman](https://publiccode.net/who-we-are/team/eric-herman.html)
+
+## Notes
+
+We started by reviewing [the notes from the last session](https://blog.publiccode.net/community%20call/2022/03/11/pruning-the-oldest-issues.html).
+
+Then we continued with:
+
+* [Add nuance on where non-English is acceptable #223](https://github.com/publiccodenet/standard/issues/223) - already fixed, closed
+* [List of standards requirements in open-standards.md #238](https://github.com/publiccodenet/standard/issues/238) - a comment was made that highlights a need for nuance, and we would like to continue work with the wording to add the suggestion
+* [Higher level navigational layer to help contributors locate codebases #345](https://github.com/publiccodenet/standard/issues/345) - we have addressed the general gist of this, closed with comment
+* [propose a marketing criterion for the Standard #264](https://github.com/publiccodenet/standard/issues/264) - the proposal is still valid, a work session is being planned for 21 April
+* [Decide if the Standard should require/expect metrics to be published #265](https://github.com/publiccodenet/standard/issues/265) - closed with comment
+* [Documentation requirements are too vague](https://github.com/publiccodenet/standard/issues/266) - relates to our latest [community call](https://blog.publiccode.net/community%20call/2022/04/11/notes-from-community-call-7-april-2022.html), stays open
+* [Standard lacks statements regarding operational requirements #267](https://github.com/publiccodenet/standard/issues/267) - a work session is planned for 25 April
+* ["Contributions MUST be small" is too subjective#268](https://github.com/publiccodenet/standard/issues/268) - a pull request has already been made, pending review
+* [Submit external links to the Internet Archive](https://github.com/publiccodenet/standard/issues/275) - a work session is being planned for 27 April
+* [Explicitly mention internationalization as good practice?](https://github.com/publiccodenet/standard/issues/277) - a work session is being planned for 9 May
+* [Reconsider how we include governance in the standard #282](https://github.com/publiccodenet/standard/issues/282) - a work session is being planned for 27 April


### PR DESCRIPTION
Aim to be published by Thursday next week

-----
[View rendered _posts/2022-04-21-pruning-the-oldest-issues.md](https://github.com/publiccodenet/blog/blob/april-prunign-call/_posts/2022-04-21-pruning-the-oldest-issues.md)