### PR TITLE
Blog post for September backlog pruning session

### DIFF
--- a/_posts/2022-09-08-pruning-the-oldest-issues.md
+++ b/_posts/2022-09-08-pruning-the-oldest-issues.md
@@ -1,0 +1,35 @@
+---
+title: "Pruning the oldest issues - September 2022"
+date: 2022-09-08
+author: Jan Ainali
+type: blogpost
+excerpt: Four issues closed, three transferred, one work session planned and one pull request made
+categories:
+  - Community call
+---
+
+# Pruning the oldest issues - September 2022
+
+## Attendees
+
+* [Jan Ainali](https://publiccode.net/who-we-are/team/jan-ainali.html)
+* [Eric Herman](https://publiccode.net/who-we-are/team/eric-herman.html)
+
+## Notes
+
+We started by reviewing [the notes from the last session](https://blog.publiccode.net/community%20call/2022/07/14/pruning-the-oldest-issues.html):
+
+* [define your product design principles #315](https://github.com/publiccodenet/standard/issues/315) - transferred to the implementation guide repository
+* [Providing a definition what transparent, accountable, understandable means in the context of public software #317](https://github.com/publiccodenet/standard/issues/317) - closed with comment
+* [Provide a definition of the core values in the context of public code #318](https://github.com/publiccodenet/standard/issues/318) - closed with comment
+* [Make the "Code in the open" MUST (unless used) more general applicable #324](https://github.com/publiccodenet/standard/issues/324) - closed with comment
+
+Then we continued with:
+
+* [Possible further reading on commit messages #337](https://github.com/publiccodenet/standard/issues/337) - transferred to the implementation guide repository
+* [Security issues medium #339](https://github.com/publiccodenet/standard/issues/339) - fixed by [#415](https://github.com/publiccodenet/standard/pull/415)
+* [Link to auditing template #350](https://github.com/publiccodenet/standard/issues/350) - we think this could be solved in synergy with [Automate review template updates #1201](https://github.com/publiccodenet/about/issues/1201), work session planned on September 12
+* [Add further reading for Ethics considerations #357](https://github.com/publiccodenet/standard/issues/357) - transferred to the implementation guide repository
+* [Add how the Standard supports the SDGs to the intro #358](https://github.com/publiccodenet/standard/issues/358) - commented about usability in the publiccode.net repository, made a [pull request](https://github.com/publiccodenet/standard/pull/695) for partial solution, stays open
+
+Last, we reviewed the [roadmap](https://standard.publiccode.net/docs/roadmap.html) and [proposed a small update](https://github.com/publiccodenet/standard/pull/696) that adjusts it to be inline with the [latest release](https://github.com/publiccodenet/standard/releases/tag/0.4.0) and the [implementation guide](https://publiccodenet.github.io/community-implementation-guide-standard/).


### PR DESCRIPTION
Can be published immediately or on Friday.

-----
[View rendered _posts/2022-09-08-pruning-the-oldest-issues.md](https://github.com/publiccodenet/blog/blob/sept-2022-backlog-pruning/_posts/2022-09-08-pruning-the-oldest-issues.md)