### PR TITLE
Skip linkcheck for "wolf criers"

### DIFF
--- a/script/test-with-link-check.sh
+++ b/script/test-with-link-check.sh
@@ -19,8 +19,11 @@ bundle exec jekyll build
 # * docs.github.com/en : blocked by github DDoS protection
 # * plausible.io/js/plausible.js : does not serve to scripts
 # * lists.publiccode.net/mailman/ : gives 500, 503 errors to scripts
-# * twitter.com : does not server scripts
+# * twitter.com : does not serve scripts
 # * linkedin.com : requires login
+# * opensource.org : gives 503 No error when run as GitHub workflow
+# * www.un.org : gives 403 No error when run as GitHub workflow
+#
 URL_IGNORE_REGEXES="\
 /github\.com\/.*\/edit\//\
 ,/docs\.github\.com\/en\//\
@@ -28,6 +31,8 @@ URL_IGNORE_REGEXES="\
 ,/lists\.publiccode\.net\/mailman/\
 ,/twitter\.com/\
 ,/linkedin\.com/\
+,/opensource\.org/\
+,/www\.un\.org\/en\/content\
 "
 
 # Check for broken links and missing alt tags:


### PR DESCRIPTION
```
Checking 574 external links...
Ran on 104 files!

- ./_site/news/2020/12/02/summer-2020-newsletter.html
  *  External link https://opensource.org/StateOfTheSource failed: 503 No error

- ./_site/news/2020/12/09/how-to-start-a-standard-compliant-repository.html
  *  External link https://opensource.org/licenses/category failed: 503 No error
- ./_site/news/2021/07/28/digital-public-goods.html
  *  External link https://www.un.org/en/content/digital-cooperation-roadmap/ failed: 403 No error

HTML-Proofer found 3 failures!
Error: Process completed with exit code 1.
```

from:
https://github.com/publiccodenet/blog/actions/runs/3232369253/jobs/5292908091
 and every run for days and days ....