### PR TITLE
Add blog post for October standard backlog pruning

### DIFF
--- a/_posts/2022-10-17-pruning-the-oldest-issues.md
+++ b/_posts/2022-10-17-pruning-the-oldest-issues.md
@@ -1,0 +1,31 @@
+---
+title: "Pruning the oldest issues - October 2022"
+date: 2022-10-17
+author: Jan Ainali
+type: blogpost
+excerpt: Two issues closed, one transferred and one pull request made
+categories:
+  - Community call
+---
+
+# Pruning the oldest issues - October 2022
+
+## Attendees
+
+* [Jan Ainali](https://publiccode.net/who-we-are/team/jan-ainali.html)
+* [Eric Herman](https://publiccode.net/who-we-are/team/eric-herman.html)
+
+## Notes
+
+We started by reviewing [the notes from the last session](https://blog.publiccode.net/community%20call/2022/09/08/pruning-the-oldest-issues.html):
+
+* [Add how the Standard supports the SDGs to the intro #358](https://github.com/publiccodenet/standard/issues/358) - transferred to publiccode.net repository
+
+Then we continued with:
+
+* [Create video on contributing to the Standard #361](https://github.com/publiccodenet/standard/issues/361) - closed for now, can be re-opened if someone wants to work on it
+* [Add something about required skills in a codebase? #362](https://github.com/publiccodenet/standard/issues/362) - closed with comment
+* [Reviews of contributions within 2 business days lacks rationale and further reading #367](https://github.com/publiccodenet/standard/issues/367) - a [pull request](https://github.com/publiccodenet/standard/pull/725) with additions to Why this is important was made
+* [Ambiguous sentence related to security #368](https://github.com/publiccodenet/standard/issues/368) - already fixed, closed
+* [Glossary items are not uniform #369](https://github.com/publiccodenet/standard/issues/369) - comments made, stays open
+* [Nice is not enough information on why a link is further reading #370](https://github.com/publiccodenet/standard/issues/370) - comment made, stays open until sentence is added to the implementation guide


### PR DESCRIPTION
Aims to be published on Monday, October 17.

-----
[View rendered _posts/2022-10-17-pruning-the-oldest-issues.md](https://github.com/publiccodenet/blog/blob/oct-2022-backlog-pruning/_posts/2022-10-17-pruning-the-oldest-issues.md)