### PR TITLE
Blog post for November Standard backlog pruning session

### DIFF
--- a/_posts/2022-11-09-pruning-the-oldest-issues.md
+++ b/_posts/2022-11-09-pruning-the-oldest-issues.md
@@ -1,0 +1,31 @@
+---
+title: "Pruning the oldest issues - November 2022"
+date: 2022-11-09
+author: Jan Ainali
+type: blogpost
+excerpt: Three issues closed, one transferred, two work sessions planned and one pull request made
+categories:
+  - Community call
+---
+
+# Pruning the oldest issues - October 2022
+
+## Attendees
+
+* [Jan Ainali](https://publiccode.net/who-we-are/team/jan-ainali.html)
+* [Eric Herman](https://publiccode.net/who-we-are/team/eric-herman.html)
+
+## Notes
+
+We started by reviewing [the notes from the last session](https://blog.publiccode.net/community%20call/2022/10/17/pruning-the-oldest-issues.html):
+
+* We scheduled a work session for [Glossary items are not uniform #369](https://github.com/publiccodenet/standard/issues/369) on 15 November
+
+Then we continued with:
+
+* [Reduce Markdown linting exceptions #373](https://github.com/publiccodenet/standard/issues/373) - we made a [pull request](https://github.com/publiccodenet/standard/pull/742)
+* [List with on-demand book printing service #374](https://github.com/publiccodenet/standard/issues/374) - split into [Add e-reader formats to release process #743](https://github.com/publiccodenet/standard/issues/743) and [Research on-demand book stores #744](https://github.com/publiccodenet/standard/issues/744) and closed
+* [Helping people use our glossary (and better understand our worldview) #375](https://github.com/publiccodenet/standard/issues/375) - comment made that this is something that we could and should do, work session planned for 23 November
+* [Additional advice for developers and designers in 'code in the open' #376](https://github.com/publiccodenet/standard/issues/376) - moved to the implementation guide repository
+* [Diversify 'further reading' in 'Code in the open' #377](https://github.com/publiccodenet/standard/issues/377) - closed with comment
+* [Require documenting policy in the codebase (as part of 'bundle policy and code') #378](https://github.com/publiccodenet/standard/issues/378) - closed with comment


### PR DESCRIPTION
Hopefully, we can publish this today.

-----
[View rendered _posts/2022-11-09-pruning-the-oldest-issues.md](https://github.com/publiccodenet/blog/blob/november-2022-pruning-session/_posts/2022-11-09-pruning-the-oldest-issues.md)