### PR TITLE
fix broken video links

### DIFF
--- a/_posts/2020-09-23-episode-one-of-lets-talk-about-public-code.md
+++ b/_posts/2020-09-23-episode-one-of-lets-talk-about-public-code.md
@@ -17,7 +17,6 @@ Recently we [shared the news](https://blog.publiccode.net/news/2020/09/01/on-air
 The video is available in a number of places:
 
 - [Youtube](https://www.youtube.com/watch?v=MFAb8QaDXFY)
-- [Periscope](https://www.pscp.tv/w/1nAKEAQlonkKL)
 - [Facebook](https://www.facebook.com/publiccodenet/videos/643877099845339/)
 
 [![Screenshot of the podcast]({{site.url}}/assets/screenshot-podcast.png)](https://www.youtube.com/watch?v=MFAb8QaDXFY)
@@ -31,7 +30,7 @@ It is also available on most podcast players, so take a few secsonds to subscrib
 - [Google Podcasts](https://podcasts.google.com/feed/aHR0cHM6Ly9wb2RjYXN0LnB1YmxpY2NvZGUubmV0L2ZlZWQueG1s)
 - [Stitcher](https://www.stitcher.com/s?fid=572446)
 - [TuneIn](https://tunein.com/podcasts/Technology-Podcasts/Lets-talk-about-public-code-p1365579/)
-- [Podcast Addict](https://podcastaddict.com/podcast/3603594)
+- [Podcast Addict](https://podcastaddict.com/podcast/lets-talk-about-public-code/3105988)
 - [PocketCast](https://pca.st/vdvtvnqc)
 - [Listen Notes](https://www.listennotes.com/podcasts/lets-talk-about-public-code-foundation-for-AOD3guWQ9BY/)
 

--- a/_posts/2021-02-03-episode-three-of-lets-talk-about-public-code.md
+++ b/_posts/2021-02-03-episode-three-of-lets-talk-about-public-code.md
@@ -23,7 +23,6 @@ You will find the podcast at [podcast.publiccode.net](https://podcast.publiccode
 The video is available in a number of places:
 
 - [Youtube](https://www.youtube.com/watch?v=1xojrumKgfA)
-- [Periscope](https://www.pscp.tv/w/1gqxvoRWjgwKB)
 - [Facebook](https://www.facebook.com/publiccodenet/videos/321846445885858/)
 
 ## What's next?

--- a/_posts/2021-03-04-episode-four-of-lets-talk-about-public-code.md
+++ b/_posts/2021-03-04-episode-four-of-lets-talk-about-public-code.md
@@ -23,7 +23,6 @@ You can find the podcast at [podcast.publiccode.net](https://podcast.publiccode.
 The video is available in a number of places:
 
 - [Youtube](https://www.youtube.com/watch?v=5iq1Mqwah7g)
-- [Periscope](https://www.pscp.tv/w/1DXxyRyyWnZKM)
 - [Facebook](https://www.facebook.com/publiccodenet/videos/430134378050506/)
 
 ## What's next?

--- a/_posts/2021-05-11-episode-five-of-lets-talk-about-public-code.md
+++ b/_posts/2021-05-11-episode-five-of-lets-talk-about-public-code.md
@@ -27,7 +27,6 @@ You can find the podcast at [podcast.publiccode.net](https://podcast.publiccode.
 The video is available in a number of places:
 
 - [Youtube](https://www.youtube.com/watch?v=zPF_3DpNA0A)
-- [Periscope](https://www.pscp.tv/w/1RDGlPvwqYlGL)
 - [Facebook](https://www.facebook.com/285004318294/videos/210340460598152)
 
 ## What's next?

--- a/_posts/2021-06-10-episode-six-of-lets-talk-about-public-code.md
+++ b/_posts/2021-06-10-episode-six-of-lets-talk-about-public-code.md
@@ -25,7 +25,6 @@ You can find the podcast at [podcast.publiccode.net](https://podcast.publiccode.
 The video is available in a number of places:
 
 - [Youtube](https://www.youtube.com/watch?v=q9wtjtgmXj0)
-- [Periscope](https://www.pscp.tv/w/1vOxwEoEMRbGB)
 - [Facebook](https://www.facebook.com/285004318294/videos/333617858326819)
 
 ## What's next?

--- a/_posts/2021-07-27-episode-seven-of-lets-talk-about-public-code.md
+++ b/_posts/2021-07-27-episode-seven-of-lets-talk-about-public-code.md
@@ -23,7 +23,6 @@ You can find the podcast at [podcast.publiccode.net](https://podcast.publiccode.
 The video is available in a number of places:
 
 - [Youtube](https://www.youtube.com/watch?v=9tqRw17qoZA)
-- [Periscope](https://www.pscp.tv/w/1ZkKzeeXXwexv)
 - [Facebook](https://www.facebook.com/285004318294/videos/539082097505441)
 
 ## What's next?

--- a/_posts/2021-09-23-episode-eight-of-lets-talk-about-public-code.md
+++ b/_posts/2021-09-23-episode-eight-of-lets-talk-about-public-code.md
@@ -25,7 +25,6 @@ You can find the podcast at [podcast.publiccode.net](https://podcast.publiccode.
 The video is available in a number of places:
 
 - [Youtube](https://www.youtube.com/watch?v=61UgINAba6k)
-- [Periscope](https://www.pscp.tv/w/1ZkJzeZoPWXGv)
 - [Facebook](https://www.facebook.com/publiccodenet/videos/580954046286169)
 
 ## What's next?

--- a/_posts/2023-09-11-notes-from-community-call-7-september-2023.md
+++ b/_posts/2023-09-11-notes-from-community-call-7-september-2023.md
@@ -19,7 +19,7 @@ categories:
 ## Updates from the Foundation
 
 * Two new codebases published their assessments towards the Standard for Public Code:
-  * [The open source repository template from the Swedish Agency for Digital Government]( https://github.com/diggsweden/open-source-project-template/blob/main/docs/standard-for-public-code-assessment.html)
+  * [The open source repository template from the Swedish Agency for Digital Government](https://github.com/diggsweden/open-source-project-template/blob/main/docs/public_code/standard-for-public-code-assessment.html)
   * [Circulaw - a knowledge platform that encourages positive circular economy regulation](https://github.com/Dark-Matter-Labs/circulaw/blob/main/docs/circulaw-standard-for-public-code.html)
 
 ## Background


### PR DESCRIPTION
remove the Periscope (pscp.tv) links, as Periscope is End-of-Life fix some moved links