### PR TITLE
rename file with space

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,6 +5,7 @@ title: Blog for Public Code
 plugins:
   - jekyll-remote-theme
   - jekyll-feed
+  - jekyll-redirect-from
 
 # Also render the README to HTML even if there is an index.md
 include:

--- a/_posts/2023-03-06-notes-from-community-call-2-march-2023.md
+++ b/_posts/2023-03-06-notes-from-community-call-2-march-2023.md
@@ -6,6 +6,11 @@ type: blogpost
 excerpt: Reflecting on the What this does not do sections
 categories:
   - Community call
+# renamed:
+#  _posts/2023-03-06-notes-from-community-call-2 march-2023.md
+#  _posts/2023-03-06-notes-from-community-call-2-march-2023.md
+redirect_from:
+  - /community call/2023/03/06/notes-from-community-call 2-march-2023.html
 ---
 
 # 2 March 2023 Standard for Public Code community call notes


### PR DESCRIPTION
because of the special URLs that blog posts are generated with, the redirect_from: in the "frontmatter" uses the path with the `.html` extension